### PR TITLE
Fix viewHolder.contentParent & recycle check at ExpandableListItemAdapter

### DIFF
--- a/library/src/com/haarman/listviewanimations/itemmanipulation/ExpandableListItemAdapter.java
+++ b/library/src/com/haarman/listviewanimations/itemmanipulation/ExpandableListItemAdapter.java
@@ -103,7 +103,7 @@ public abstract class ExpandableListItemAdapter<T> extends ArrayAdapter<T> {
 		}
 
 		View titleView = getTitleView(position, viewHolder.titleView, viewHolder.titleParent);
-		if (!titleView.equals(viewHolder.titleView)) {
+		if (titleView != viewHolder.titleView) {
 			viewHolder.titleParent.removeAllViews();
 			viewHolder.titleParent.addView(titleView);
 
@@ -116,11 +116,11 @@ public abstract class ExpandableListItemAdapter<T> extends ArrayAdapter<T> {
 		viewHolder.titleView = titleView;
 
 		View contentView = getContentView(position, viewHolder.contentView, viewHolder.contentParent);
-		if (!contentView.equals(viewHolder.contentView)) {
+		if (contentView != viewHolder.contentView) {
 			viewHolder.contentParent.removeAllViews();
 			viewHolder.contentParent.addView(contentView);
 		}
-		viewHolder.titleView = titleView;
+		viewHolder.contentParent = contentParent;
 
 		viewHolder.contentParent.setVisibility(mVisibleIds.contains(getItemId(position)) ? View.VISIBLE : View.GONE);
 		viewHolder.contentParent.setTag(getItemId(position));


### PR DESCRIPTION
Line 123: `viewHolder.contentParent` wasn't setted.

Line 106 & 119: You must check that they are the same instance.
