### PR TITLE
ContextualUndoAdapter, How to click item ?

### DIFF
--- a/library/src/com/haarman/listviewanimations/itemmanipulation/contextualundo/ContextualUndoAdapter.java
+++ b/library/src/com/haarman/listviewanimations/itemmanipulation/contextualundo/ContextualUndoAdapter.java
@@ -134,6 +134,7 @@ public class ContextualUndoAdapter extends BaseAdapterDecorator implements Conte
 		ContextualUndoView contextualUndoView = (ContextualUndoView) convertView;
 		if (contextualUndoView == null) {
 			contextualUndoView = new ContextualUndoView(parent.getContext(), mUndoLayoutId, mCountDownTextViewResId);
+			contextualUndoView.getChildAt(0).setOnClickListener(null);
 			contextualUndoView.findViewById(mUndoActionId).setOnClickListener(new UndoListener(contextualUndoView));
 		}
 


### PR DESCRIPTION
I am not really sure how to deal with item click on ContextualUndoAdapter. The example doesn't mention it. There are at least two ways item click is handled:
1. By hooking a View.OnClickListener to a view in the row. This view will no longer respond to swipe though.
2. By hooking AdapterView.OnItemClickListener to the listview. In this case we need to restrict which clicks go to that listener. Consider the case of Undo Layout that looks like
![device-2013-11-05-123834](https://f.cloud.github.com/assets/348426/1470885/f0a899ea-45cb-11e3-8815-e7a51eb227b1.png)
If mUndoActionId corresponds to "Tap to Undo" view then clicking the other views (like "Deleted") will still trigger OnItemClick. 
I propose root view of the undo layout is set with null listener. With it other views except mUndoActionId will not respond to click. But I do not know if other people have different needs / customizations of their own Undo Layout. 
