### PR TITLE
Fix accidental calls to setAdapter(ListAdapter)

### DIFF
--- a/library/src/com/haarman/listviewanimations/view/DynamicListView.java
+++ b/library/src/com/haarman/listviewanimations/view/DynamicListView.java
@@ -148,7 +148,10 @@ public class DynamicListView extends ListView {
 	 * @deprecated use #setAdapter(BaseAdapter) instead.
 	 */
 	public void setAdapter(ListAdapter adapter) {
-		throw new IllegalArgumentException("DynamicListView needs a BaseAdapter!");
+		if (!(adapter instanceof BaseAdapter)) {
+			throw new IllegalArgumentException("DynamicListView needs a BaseAdapter!");
+		}
+		super.setAdapter(adapter);
 	}
 
 	/**


### PR DESCRIPTION
This issue took me a lot of time to understand. This code throws an `IllegalArgumentException`:

``` java
BaseAdapter baseAdapter = new SomeBaseAdapter();
ListView listview = getListView(); // listView instance of DynamicListView
listView.setAdapter(baseAdapter); // IllegalArgumentException!!
```

But this don't:

``` java
BaseAdapter baseAdapter = new SomeBaseAdapter();
DynamicListView listview = (DynamicListView) getListView();
listView.setAdapter(baseAdapter); // all ok
```

This PR prevents this strange behaviour.
