### PR TITLE
add Android.mk files to enable building in tree

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,14 @@
+LOCAL_PATH:= $(call my-dir)
+include $(call all-subdir-makefiles)
+########################################################
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_STATIC_JAVA_LIBRARIES := listviewanimations_prebuilt
+
+LOCAL_PREBUILT_STATIC_JAVA_LIBRARIES := listviewanimations_prebuilt:com.haarman.listviewanimations-2.5.2.jar
+
+include $(BUILD_MULTI_PREBUILT)
+
+########################################################

--- a/library/Android.mk
+++ b/library/Android.mk
@@ -1,0 +1,31 @@
+LOCAL_PATH := $(call my-dir)
+
+#####################################################################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_STATIC_JAVA_LIBRARIES := nineoldandroids stickylistheaders
+
+LOCAL_SRC_FILES := $(call all-subdir-java-files, src)
+
+LOCAL_MODULE := ListViewAnimations
+
+include $(BUILD_STATIC_JAVA_LIBRARY)
+
+#####################################################################
+
+include $(CLEAR_VARS)
+
+LOCAL_PREBUILT_STATIC_JAVA_LIBRARIES := nineoldandroids:libs/nineoldandroids-2.4.0.jar
+
+include $(BUILD_MULTI_PREBUILT)
+
+#####################################################################
+
+include $(CLEAR_VARS)
+
+LOCAL_PREBUILT_STATIC_JAVA_LIBRARIES := stickylistheaders:libs/stickylistheaders_lib.jar
+
+include $(BUILD_MULTI_PREBUILT)


### PR DESCRIPTION
  to use the library in your app, edit the apps Android.mk and do EITHER 1 OR 2
1. build from source (recommended)
   
   ```
   add the following line
   LOCAL_STATIC_JAVA_LIBRARIES := ListViewAnimations
   ```
2. use prebuilt jar (adding a provision, but not recommended to use this way)
   
   ```
   add the following line
   LOCAL_STATIC_JAVA_LIBRARIES := listviewanimations_prebuilt
   ```

Signed-off-by: Arnav Gupta championswimmer@aokp.co
