### PR TITLE
Fix NPE after Exp[15]Adapter's simple constructor.

### DIFF
--- a/library/src/com/haarman/listviewanimations/itemmanipulation/ExpandableListItemAdapter.java
+++ b/library/src/com/haarman/listviewanimations/itemmanipulation/ExpandableListItemAdapter.java
@@ -54,6 +54,7 @@ public abstract class ExpandableListItemAdapter<T> extends ArrayAdapter<T> {
 		mContentParentResId = DEFAULTCONTENTPARENTRESID;
 
 		mVisibleIds = new ArrayList<Long>();
+		mExpandedViews = new HashMap<Long, View>();
 	}
 
 	/**


### PR DESCRIPTION
The `ExpandableListItemAdapter.<init>(Context, List<T>)` constructor fails to
initialize the `mExpandedViews` field, causing the adapter to throw an NPE 
when you first fold an item closed.

A work-around while using 2.5.2 is to use the constructor that takes three
resId's in addition to the `Context` and the array, but you need to know to
use 0, 10000 and 10001, respectively, or it'll NPE elsewhere.
