### PR TITLE
Fixed crash when the listview has footerViews

### DIFF
--- a/library/src/com/nhaarman/listviewanimations/widget/DynamicListView.java
+++ b/library/src/com/nhaarman/listviewanimations/widget/DynamicListView.java
@@ -191,7 +191,7 @@ public class DynamicListView extends ListView {
         int position = pointToPosition(mDownX, mDownY);
         int itemNum = position - getFirstVisiblePosition();
         View selectedView = getChildAt(itemNum);
-        if (selectedView == null || position < getHeaderViewsCount() || position >= getAdapter().getCount() - getHeaderViewsCount()) {
+        if (selectedView == null || position < getHeaderViewsCount() || position >= getAdapter().getCount() - getHeaderViewsCount() - getFooterViewsCount()) {
             return;
         }
 


### PR DESCRIPTION
Stop the library from trying to drag and animate footer views, as they do not come from the adapter.
