### PR TITLE
Adding ArrayAdapter.sort() method

### DIFF
--- a/library/src/com/nhaarman/listviewanimations/ArrayAdapter.java
+++ b/library/src/com/nhaarman/listviewanimations/ArrayAdapter.java
@@ -23,6 +23,7 @@ import com.nhaarman.listviewanimations.widget.DynamicListView;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -236,6 +237,17 @@ public abstract class ArrayAdapter<T> extends BaseAdapter implements List<T>, Dy
         boolean result = mItems.retainAll(objects);
         notifyDataSetChanged();
         return result;
+    }
+
+    /**
+     * Sorts the content of this adapter using the specified comparator.
+     *
+     * @param comparator The comparator used to sort the objects contained
+     *        in this adapter.
+     */
+    public void sort(Comparator<? super T> comparator) {
+    	Collections.sort(mItems, comparator);
+    	notifyDataSetChanged();
     }
 
     @Override


### PR DESCRIPTION
Providing a convenience `sort()` method, just like [Google's ArrayAdapter does](http://developer.android.com/reference/android/widget/ArrayAdapter.html#sort%28java.util.Comparator%3C?%20super%20T%3E%29).
