### PR TITLE
Fix manifest sdk version

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
     package="com.haarman.listviewanimations">
 
     <uses-permission android:name="com.android.vending.BILLING" />
+    
+    <uses-sdk
+        android:minSdkVersion="14"
+        android:targetSdkVersion="19" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
The _AndroidManifest.xml_ file did not define `minSdkVersion` and `targetSdkVersion`. This resulted in a pixelated app with the maven build. This PR fixes this issue by adding the versions to the manifest.
