### PR TITLE
Feature: Add setDismissableManager at Adapter level

### DIFF
--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/swipedismiss/SwipeDismissAdapter.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/swipedismiss/SwipeDismissAdapter.java
@@ -73,6 +73,18 @@ public class SwipeDismissAdapter extends BaseAdapterDecorator {
     }
 
     /**
+     * Sets the {@link com.nhaarman.listviewanimations.itemmanipulation.swipedismiss.DismissableManager} to specify which views can or cannot be swiped.
+     *
+     * @param dismissableManager {@code null} for no restrictions.
+     */
+    public void setDismissableManager(@Nullable final DismissableManager dismissableManager) {
+        if (mDismissTouchListener == null) {
+            throw new IllegalStateException("You must call setAbsListView() first.");
+        }
+        mDismissTouchListener.setDismissableManager(dismissableManager);
+    }
+
+    /**
      * If the adapter's {@link android.widget.AbsListView} is hosted inside a parent(/grand-parent/etc) that can scroll horizontally, horizontal swipes won't
      * work, because the parent will prevent touch-events from reaching the {@code AbsListView}.
      * <p/>

--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/swipedismiss/undo/SwipeUndoAdapter.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/swipedismiss/undo/SwipeUndoAdapter.java
@@ -23,6 +23,7 @@ import android.widget.BaseAdapter;
 
 import com.nhaarman.listviewanimations.BaseAdapterDecorator;
 import com.nhaarman.listviewanimations.itemmanipulation.DynamicListView;
+import com.nhaarman.listviewanimations.itemmanipulation.swipedismiss.DismissableManager;
 import com.nhaarman.listviewanimations.util.ListViewWrapper;
 
 /**
@@ -61,6 +62,18 @@ public abstract class SwipeUndoAdapter extends BaseAdapterDecorator {
         if (!(listViewWrapper.getListView() instanceof DynamicListView)) {
             listViewWrapper.getListView().setOnTouchListener(mSwipeUndoTouchListener);
         }
+    }
+
+    /**
+     * Sets the {@link com.nhaarman.listviewanimations.itemmanipulation.swipedismiss.DismissableManager} to specify which views can or cannot be swiped.
+     *
+     * @param dismissableManager {@code null} for no restrictions.
+     */
+    public void setDismissableManager(@Nullable final DismissableManager dismissableManager) {
+        if (mSwipeUndoTouchListener == null) {
+            throw new IllegalStateException("You must call setAbsListView() first.");
+        }
+        mSwipeUndoTouchListener.setDismissableManager(dismissableManager);
     }
 
     public void setSwipeUndoTouchListener(@NonNull final SwipeUndoTouchListener swipeUndoTouchListener) {


### PR DESCRIPTION
Right now if you want to use a `DismissableManager` you must get the `DismissTouchListener` and then set the `DismissableManager`. This is not a good thing because you really don't want to know about `DismissTouchListener` at `SwipeDismissAdapter` level.

In the case of `SwipeUndoAdapter` it was imposible to use `DismissableManager`. There is not a getter for get the `SwipeUndoTouchListener` instance.

This PR have a minor fix too: an annotation.
