### PR TITLE
Fixing StickyListHeadersListViewWrapper.getChildAt()

### DIFF
--- a/lib-core-slh/src/main/java/com/nhaarman/listviewanimations/util/StickyListHeadersListViewWrapper.java
+++ b/lib-core-slh/src/main/java/com/nhaarman/listviewanimations/util/StickyListHeadersListViewWrapper.java
@@ -41,7 +41,7 @@ public class StickyListHeadersListViewWrapper implements ListViewWrapper {
     @Nullable
     @Override
     public View getChildAt(final int index) {
-        return mListView.getChildAt(index);
+        return mListView.getListChildAt(index);
     }
 
     @Override


### PR DESCRIPTION
The method getChildAt() on StickyListHeadersListView is inherited from the FrameLayout base class. This cause a NPE when using SwipeDismissAdapter with StickyListHeadersListViewWrapper.
