### PR TITLE
Fixing StickyListHeadersListViewWrapper getChildCount

### DIFF
--- a/lib-core-slh/src/main/java/com/nhaarman/listviewanimations/util/StickyListHeadersListViewWrapper.java
+++ b/lib-core-slh/src/main/java/com/nhaarman/listviewanimations/util/StickyListHeadersListViewWrapper.java
@@ -61,7 +61,7 @@ public class StickyListHeadersListViewWrapper implements ListViewWrapper {
 
     @Override
     public int getChildCount() {
-        return mListView.getChildCount();
+        return mListView.getWrappedList().getChildCount();
     }
 
     @Override


### PR DESCRIPTION
StickyListHeadersListView getChildCount() returns always 1 (StickyListHeadersListView is a FrameLayout).
