### PR TITLE
Drag a list item which is really pointed

### DIFF
--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/DragAndDropHandler.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/DragAndDropHandler.java
@@ -110,12 +110,17 @@ public class DragAndDropHandler implements TouchEventHandler {
     /**
      * The raw x coordinate of the down event.
      */
-    private float mDownX;
+    private float mRawDownX;
 
     /**
      * The raw y coordinate of the down event.
      */
-    private float mDownY;
+    private float mRawDownY;
+
+    /**
+     * The x and y coordinate of the down event.
+     */
+    private float mDownX, mDownY;
 
     /**
      * Specifies whether or not the hover drawable is currently being animated as result of an up / cancel event.
@@ -304,8 +309,10 @@ public class DragAndDropHandler implements TouchEventHandler {
      * @return {@code true} if we have started dragging, {@code false} otherwise.
      */
     private boolean handleDownEvent(@NonNull final MotionEvent event) {
-        mDownX = event.getRawX();
-        mDownY = event.getRawY();
+        mRawDownX = event.getRawX();
+        mRawDownY = event.getRawY();
+        mDownX = event.getX();
+        mDownY = event.getY();
         return true;
     }
 
@@ -362,15 +369,15 @@ public class DragAndDropHandler implements TouchEventHandler {
     private boolean handleMoveEvent(@NonNull final MotionEvent event) {
         boolean handled = false;
 
-        float deltaX = event.getRawX() - mDownX;
-        float deltaY = event.getRawY() - mDownY;
+        float deltaX = event.getRawX() - mRawDownX;
+        float deltaY = event.getRawY() - mRawDownY;
 
         if (mHoverDrawable == null && Math.abs(deltaY) > mSlop && Math.abs(deltaY) > Math.abs(deltaX)) {
-            int position = mWrapper.pointToPosition((int) event.getX(), (int) event.getY());
+            int position = mWrapper.pointToPosition((int) mDownX, (int) mDownY);
             if (position != AdapterView.INVALID_POSITION) {
                 View downView = mWrapper.getChildAt(position - mWrapper.getFirstVisiblePosition());
                 assert downView != null;
-                if (mDraggableManager.isDraggable(downView, position - mWrapper.getHeaderViewsCount(), event.getX() - downView.getX(), event.getY() - downView.getY())) {
+                if (mDraggableManager.isDraggable(downView, position - mWrapper.getHeaderViewsCount(), mDownX - downView.getX(), mDownY - downView.getY())) {
                     startDragging(position - mWrapper.getHeaderViewsCount());
                     handled = true;
                 }


### PR DESCRIPTION
Currently, drag and drop handler chooses a list item
which is located at some moved point.
But it has little difference from the point at touch down.

This pull request fixes DragAndDropHandler to drag a list item
which is located at touch down.
