### PR TITLE
Unwrap StickyListHeaders item before use

### DIFF
--- a/lib-core-slh/src/main/java/com/nhaarman/listviewanimations/util/StickyListHeadersListViewWrapper.java
+++ b/lib-core-slh/src/main/java/com/nhaarman/listviewanimations/util/StickyListHeadersListViewWrapper.java
@@ -22,6 +22,7 @@ import android.view.View;
 import android.widget.ListAdapter;
 
 import se.emilsjolander.stickylistheaders.StickyListHeadersListView;
+import se.emilsjolander.stickylistheaders.WrapperView;
 
 public class StickyListHeadersListViewWrapper implements ListViewWrapper {
 
@@ -41,7 +42,7 @@ public class StickyListHeadersListViewWrapper implements ListViewWrapper {
     @Nullable
     @Override
     public View getChildAt(final int index) {
-        return mListView.getListChildAt(index);
+        return unwrapItemView(mListView.getListChildAt(index));
     }
 
     @Override
@@ -61,7 +62,7 @@ public class StickyListHeadersListViewWrapper implements ListViewWrapper {
 
     @Override
     public int getChildCount() {
-        return mListView.getChildCount();
+        return mListView.getListChildCount();
     }
 
     @Override
@@ -83,5 +84,12 @@ public class StickyListHeadersListViewWrapper implements ListViewWrapper {
     @Override
     public void smoothScrollBy(final int distance, final int duration) {
         mListView.smoothScrollBy(distance, duration);
+    }
+
+    public View unwrapItemView(final View view) {
+        if (view instanceof WrapperView) {
+            return ((WrapperView) view).getItem();
+        }
+        return view;
     }
 }


### PR DESCRIPTION
Fix for https://github.com/nhaarman/ListViewAnimations/issues/240

1) Fixes the getChildCount() method from StickyListHeadersListViewWrapper 

``` java
@Override
public int getChildCount() {
    return mListView.getListChildCount();
}
```

2) Unwraps the item from WrapperView before trying to find a ListViewAnimations' tags from it:

``` java
public View unwrapItemView(final View view) {
    if (view instanceof WrapperView) {
        return ((WrapperView) view).getItem();
    }
    return view;
}

@Override
public View getChildAt(int index) {
    return unwrapItemView(super.getChildAt(index));
}
```
