### PR TITLE
Moving canceled

### DIFF
--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/DragAndDropHandler.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/DragAndDropHandler.java
@@ -458,8 +458,12 @@ public class DragAndDropHandler implements TouchEventHandler {
         valueAnimator.start();
 
         int newPosition = getPositionForId(mMobileItemId) - mWrapper.getHeaderViewsCount();
-        if (mOriginalMobileItemPosition != newPosition && mOnItemMovedListener != null) {
-            mOnItemMovedListener.onItemMoved(mOriginalMobileItemPosition, newPosition);
+        if(mOnItemMovedListener != null){
+            if (mOriginalMobileItemPosition != newPosition) {
+                mOnItemMovedListener.onItemMoved(mOriginalMobileItemPosition, newPosition);
+            }else{
+                mOnItemMovedListener.onMovingCanceled(mOriginalMobileItemPosition);
+            }
         }
 
         return true;

--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/DragAndDropHandler.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/DragAndDropHandler.java
@@ -107,6 +107,14 @@ public class DragAndDropHandler implements TouchEventHandler {
     @Nullable
     private OnItemMovedListener mOnItemMovedListener;
 
+
+
+    /**
+     * The {@link OnItemMovingCanceledListener} that is notified of moved items.
+     */
+    @Nullable
+    private OnItemMovingCanceledListener mOnItemMovingCanceledListener;
+
     /**
      * The raw x coordinate of the down event.
      */
@@ -250,6 +258,13 @@ public class DragAndDropHandler implements TouchEventHandler {
         mOnItemMovedListener = onItemMovedListener;
     }
 
+
+    /**
+     * Sets the {@link com.nhaarman.listviewanimations.itemmanipulation.dragdrop.OnItemMovingCanceledListener} that is notified when user has dropped a dragging item in its original position.
+     */
+    public void setOnItemMovingCanceledListener(@Nullable final OnItemMovingCanceledListener onItemMovingCanceledListener) {
+        mOnItemMovingCanceledListener = onItemMovingCanceledListener;
+    }
     @Override
     public boolean isInteracting() {
         return mMobileItemId != INVALID_ID;
@@ -441,7 +456,12 @@ public class DragAndDropHandler implements TouchEventHandler {
      * Handles the up event.
      * <p/>
      * Animates the hover drawable to its final position, and finalizes our drag properties when the animation has finished.
+     *
      * Will also notify the {@link com.nhaarman.listviewanimations.itemmanipulation.dragdrop.OnItemMovedListener} set if applicable.
+     *
+     * Will also notify the
+     * {@link com.nhaarman.listviewanimations.itemmanipulation.dragdrop.OnItemMovingCanceledListener}
+     * if user drop item in its original position.
      *
      * @return {@code true} if the event was handled, {@code false} otherwise.
      */
@@ -458,13 +478,17 @@ public class DragAndDropHandler implements TouchEventHandler {
         valueAnimator.start();
 
         int newPosition = getPositionForId(mMobileItemId) - mWrapper.getHeaderViewsCount();
-        if(mOnItemMovedListener != null){
             if (mOriginalMobileItemPosition != newPosition) {
-                mOnItemMovedListener.onItemMoved(mOriginalMobileItemPosition, newPosition);
+
+                if(mOnItemMovedListener != null) {
+                    mOnItemMovedListener.onItemMoved(mOriginalMobileItemPosition, newPosition);
+                }
             }else{
-                mOnItemMovedListener.onMovingCanceled(mOriginalMobileItemPosition);
+                if(mOnItemMovingCanceledListener != null){
+                    mOnItemMovingCanceledListener.onItemMovingCanceled(mOriginalMobileItemPosition);
+                }
+
             }
-        }
 
         return true;
     }

--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/OnItemMovedListener.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/OnItemMovedListener.java
@@ -29,11 +29,4 @@ public interface OnItemMovedListener {
      */
     void onItemMoved(int originalPosition, int newPosition);
 
-    /**
-     * Called when an item that was dragged has been dropped without moving to new position.
-     *
-     * @param originalPosition the original position of the item that was dragged.
-     *
-     */
-    void onMovingCanceled(int originalPosition);
 }

--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/OnItemMovedListener.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/OnItemMovedListener.java
@@ -28,4 +28,12 @@ public interface OnItemMovedListener {
      * @param newPosition the new position of the item that was dragged.
      */
     void onItemMoved(int originalPosition, int newPosition);
+
+    /**
+     * Called when an item that was dragged has been dropped without moving to new position.
+     *
+     * @param originalPosition the original position of the item that was dragged.
+     *
+     */
+    void onMovingCanceled(int originalPosition);
 }

--- a/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/OnItemMovingCanceledListener.java
+++ b/lib-manipulation/src/main/java/com/nhaarman/listviewanimations/itemmanipulation/dragdrop/OnItemMovingCanceledListener.java
@@ -1,0 +1,17 @@
+package com.nhaarman.listviewanimations.itemmanipulation.dragdrop;
+
+/**
+ * An interface which provides a callback that is called when an item's moving has been canceled
+ * using the {@link com.nhaarman.listviewanimations.itemmanipulation.DynamicListView}.
+ * It usually happens when user drags item but then drop it back to its original position
+ */
+public interface OnItemMovingCanceledListener {
+
+    /**
+     * Called when an item that was dragged has been dropped without moving to new position.
+     *
+     * @param originalPosition the original position of the item that was dragged.
+     *
+     */
+    void onItemMovingCanceled(int originalPosition);
+}


### PR DESCRIPTION
I use the library for tree data structure. Before I start dragging item in tree-view, I must collapse selected view if it has some children. 
Then I have to expand it again after dropping.

Example:
```java

listView.setOnItemLongClickListener(
        new AdapterView.OnItemLongClickListener() {
            @Override
            public boolean onItemLongClick(final AdapterView<?> parent, final View view,
                                           final int position, final long id) {
                myAdapter.setCollapsed(position);
                new Handler().postDelayed(new Runnable() {
                    @Override
                    public void run() {
                        listView.startDragging(position);
                    }
                }, 50);
                return true;
            }
        }
);

listView.setOnItemMovedListener(new OnItemMovedListener() {
    @Override
    public void onItemMoved(int to, int from) {
        myAdapter.setExpanded(from);
    }

});

listView.setOnItemMovingCanceledListener(new OnItemMovingCanceledListener() {
    @Override
    public void onItemMovingCanceled(int originalPosition) {
        myAdapter.setExpanded(originalPosition);
    }
});


```
