### PR TITLE
adding removeAll to more closely mirror arraylist methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,10 @@ When describing an issue, be precise:
 * What happened? What do you think should have happened?
 * On what Android version does this issue occur?
 
+# Asking Questions
+
+Asking questions should preferably be done on a dedicated forum such as [StackOverflow](http://stackoverflow.com/). This is an issue tracker after all. 
+
 # Contributing code
 
 ## Please do!

--- a/lib-core/src/main/java/com/nhaarman/listviewanimations/ArrayAdapter.java
+++ b/lib-core/src/main/java/com/nhaarman/listviewanimations/ArrayAdapter.java
@@ -24,6 +24,7 @@ import com.nhaarman.listviewanimations.util.Swappable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -134,6 +135,20 @@ public abstract class ArrayAdapter<T> extends BaseAdapter implements Swappable, 
         T result = mItems.remove(location);
         notifyDataSetChanged();
         return result;
+    }
+
+    public boolean removeAll(@NonNull Collection<?> c) {
+        boolean modified = false;
+        Iterator<?> e = this.mItems.iterator();
+        while (e.hasNext()) {
+            if (c.contains(e.next())) {
+                e.remove();
+                modified = true;
+            }
+        }
+        if(modified)
+            this.notifyDataSetChanged();
+        return modified;
     }
 
     @Override


### PR DESCRIPTION
for uses where u need to remove more than one object at a time prior to notifying data set changes

i have a gridview with AbsListView.MultiChoiceModeListener implemented so a user can check multiple objects and click delete - with a loop and remove() once at a time, many notify were called, messing up view hierarchy a bit/glitchy