### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/lib-manipulation/src/main/AndroidManifest.xml
+++ b/lib-manipulation/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
     package="com.nhaarman.listviewanimations.itemmanipulation"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true">
+    <application>
         <activity android:name="com.nhaarman.listviewanimations.itemmanipulation.swipedismiss.SwipeTouchListenerTestActivity" />
         <activity android:name="com.nhaarman.listviewanimations.itemmanipulation.dragdrop.DynamicListViewTestActivity" />
     </application>


### PR DESCRIPTION
Removed  android:allowBackup="true" because it forces the Android Project I'm working on to also use it otherwise it will throw a Manifest Merger conflict.
